### PR TITLE
Remove video prefix from label

### DIFF
--- a/src/VideoMeta.php
+++ b/src/VideoMeta.php
@@ -24,7 +24,7 @@ class VideoMeta
     {
         $attachment = $this->attachment;
 
-        return Text::make(trans("Video $label"), "{$attachment}_file_{$name}")
+        return Text::make(trans($label), "{$attachment}_file_{$name}")
             ->readonly()
             ->exceptOnForms()
             ->displayUsing(function($value, $model) use ($attachment, $name) {


### PR DESCRIPTION
Maybe it would be good to remove the video prefix, as it doesn't provide any additional detail, in order to clear up some room and make it feel less cluttered.

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/22045687/176405453-a7911c33-d5c8-47fd-8b9f-92d7dc3a0d3a.png">

vs

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/22045687/176405546-92388854-d992-42af-9660-835778273e35.png">


